### PR TITLE
Implement LLVM.General.Module.writeModule

### DIFF
--- a/src/LLVM/General/Internal/FFI/Module.hs
+++ b/src/LLVM/General/Internal/FFI/Module.hs
@@ -84,3 +84,6 @@ moduleAppendInlineAsm m (ModuleAsm (c, n)) = moduleAppendInlineAsm' m c n
 
 foreign import ccall unsafe "LLVM_General_ModuleGetInlineAsm" moduleGetInlineAsm ::
   Ptr Module -> IO (ModuleAsm CString)
+
+foreign import ccall unsafe "LLVMWriteBitcodeToFile" writeBitcodeToFile ::
+  Ptr Module -> CString -> IO Int

--- a/src/LLVM/General/Internal/Module.hs
+++ b/src/LLVM/General/Internal/Module.hs
@@ -16,6 +16,7 @@ import Control.Exception
 
 import Foreign.Ptr
 import Foreign.Marshal.Alloc (free)
+import Foreign.C.String (withCString)
 
 import qualified LLVM.General.Internal.FFI.Assembly as FFI
 import qualified LLVM.General.Internal.FFI.Builder as FFI
@@ -67,6 +68,11 @@ withModuleFromString (Context c) s f = flip runAnyContT return $ do
 -- | generate LLVM assembly from a 'Module'
 moduleString :: Module -> IO String
 moduleString (Module m) = bracket (FFI.getModuleAssembly m) free $ decodeM
+
+writeModule :: FilePath -> Module -> IO ()
+writeModule path (Module m) = do
+  result <- withCString path (FFI.writeBitcodeToFile m)
+  when (result /= 0) $ fail ("Failed to write bitcode to " ++ path)
 
 setTargetTriple :: Ptr FFI.Module -> String -> IO ()
 setTargetTriple m t = flip runAnyContT return $ do

--- a/src/LLVM/General/Module.hs
+++ b/src/LLVM/General/Module.hs
@@ -4,6 +4,7 @@ module LLVM.General.Module (
     Module,
     withModuleFromAST,
     moduleAST,
+    writeModule,
     withModuleFromString,
     moduleString
   ) where


### PR DESCRIPTION
This enables easy writing of bitcode.

This should be added to the other live branches as well, but 3.3 is the stable version so it seemed the best base.
