### PR TITLE
Link libraries depended on by LLVM

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -61,6 +61,7 @@ main = do
                         "3.2" -> "LLVM-3.2svn"
                         x -> "LLVM-" ++ x
       staticLibs <- liftM (map (fromJust . stripPrefix "-l") . words) $ llvmConfig ["--libs"]
+      externLibs <- liftM (mapMaybe (stripPrefix "-l") . words) $ llvmConfig ["--ldflags"]
 
       let genericPackageDescription' = genericPackageDescription {
             condLibrary = do
@@ -72,8 +73,8 @@ main = do
                 condTreeComponents = condTreeComponents libraryCondTree ++ [
                   (
                     Var (Flag (FlagName "shared-llvm")),
-                    CondNode (mempty { libBuildInfo = mempty { extraLibs = [sharedLib] } }) [] [],
-                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs = staticLibs } }) [] [])
+                    CondNode (mempty { libBuildInfo = mempty { extraLibs = externLibs ++ [sharedLib] } }) [] [],
+                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs = externLibs ++ staticLibs } }) [] [])
                   )
                 ] 
               }


### PR DESCRIPTION
This explicitly pulls in higher-order library dependencies, and gets us closer to building on windows. Unfortunately, on my configuration I still have undefined references to `_imp__SymSetOptions@4` and `_imp__SymInitialize@12` (note single leading underscores). SymSetOptions and SymInitialize are ostensibly provided by libdbghelp.a, but nm only detects versions with two leading underscores there.
