### PR TITLE
Fix library ordering

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -73,8 +73,8 @@ main = do
                 condTreeComponents = condTreeComponents libraryCondTree ++ [
                   (
                     Var (Flag (FlagName "shared-llvm")),
-                    CondNode (mempty { libBuildInfo = mempty { extraLibs = externLibs ++ [sharedLib] } }) [] [],
-                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs = externLibs ++ staticLibs } }) [] [])
+                    CondNode (mempty { libBuildInfo = mempty { extraLibs = [sharedLib] ++ externLibs } }) [] [],
+                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs = staticLibs ++ externLibs } }) [] [])
                   )
                 ] 
               }


### PR DESCRIPTION
This fixes building on Win32. Note that Win32 users of LLVM still segfault mysteriously.
