### PR TITLE
Search for and use a versioned llvm-config if available

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -24,8 +24,8 @@ uncheckedHsFFIDefines = ["__STDC_LIMIT_MACROS"]
 
 llvmVersion = Version [3,3] []
 
-llvmConfigNames = [ "llvm-config"
-                  , "llvm-config-" ++ (intercalate "." . map show . versionBranch $ llvmVersion)
+llvmConfigNames = [ "llvm-config-" ++ (intercalate "." . map show . versionBranch $ llvmVersion)
+                  , "llvm-config"
                   ]
 
 llvmProgram = (simpleProgram "llvm-config")


### PR DESCRIPTION
This enables automatic buildtime compatibility with [the Debian and Ubuntu packages hosted at llvm.org](http://llvm.org/apt/). Priority is given to the versioned llvm-config (e.g. llvm-config-3.3) to better support systems with multiple LLVMs installed.

This should ease the build on Travis CI machines, which run Ubuntu 12.04.

It would be nice to extract llvmVersion out of the package version via `pkgVersion . package . localPkgDescr :: LocalBuildInfo -> Version`, but the LBI doesn't seem to be available in `hookedPrograms`, and I'm not sure if there's a good way to restructure that.
