### PR TITLE
Add support for reading in a bitcode module from a file.

### DIFF
--- a/llvm-general/src/LLVM/General/Internal/FFI/Module.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/Module.hs
@@ -7,6 +7,7 @@ import Foreign.Ptr
 import Foreign.C
 
 import LLVM.General.Internal.FFI.Context
+import LLVM.General.Internal.FFI.SMDiagnostic
 import LLVM.General.Internal.FFI.LLVMCTypes
 import LLVM.General.Internal.FFI.PtrHierarchy
 
@@ -88,6 +89,9 @@ foreign import ccall unsafe "LLVM_General_ModuleGetInlineAsm" moduleGetInlineAsm
 
 foreign import ccall unsafe "LLVM_General_WriteBitcodeToFile" writeBitcodeToFile ::
   Ptr Module -> CString -> Ptr MallocedCString -> IO LLVMBool
+
+foreign import ccall unsafe "LLVM_General_ParseIRFile" parseIRFile ::
+  Ptr Context -> CString -> Ptr SMDiagnostic -> IO (Ptr Module)
 
 foreign import ccall unsafe "LLVMLinkModules" linkModules ::
   Ptr Module -> Ptr Module -> LinkerMode -> Ptr MallocedCString -> IO LLVMBool

--- a/llvm-general/src/LLVM/General/Internal/FFI/ModuleC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/ModuleC.cpp
@@ -2,6 +2,7 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
 #include "llvm-c/Core.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Bitcode/ReaderWriter.h"
@@ -66,6 +67,10 @@ LLVMBool LLVM_General_WriteBitcodeToFile(LLVMModuleRef m, const char *path, char
 
   WriteBitcodeToFile(unwrap(m), OS);
   return 0;
+}
+
+LLVMModuleRef LLVM_General_ParseIRFile(LLVMContextRef context, const char *path, SMDiagnostic *error) {
+	return wrap(ParseIRFile(path, *error, *unwrap(context)));
 }
 
 }

--- a/llvm-general/src/LLVM/General/Module.hs
+++ b/llvm-general/src/LLVM/General/Module.hs
@@ -5,6 +5,8 @@ module LLVM.General.Module (
     withModuleFromAST,
     moduleAST,
     withModuleFromString,
+    withModuleFromIRFile,
+    parseASTFromIRFile,
     moduleString,
 
     moduleAssembly,


### PR DESCRIPTION
I'd like to use llvm-general for program analysis on LLVM modules; this necessitates being able to read in a module from a file. This commit would add that support.
