### PR TITLE
Add missing Typeable and Data instances

### DIFF
--- a/llvm-general-pure/src/LLVM/General/AST.hs
+++ b/llvm-general-pure/src/LLVM/General/AST.hs
@@ -16,6 +16,8 @@ module LLVM.General.AST (
   module LLVM.General.AST.Type
   ) where
 
+import Data.Data
+
 import LLVM.General.AST.Name
 import LLVM.General.AST.Type
 import LLVM.General.AST.Global
@@ -30,7 +32,7 @@ data Definition
   | MetadataNodeDefinition MetadataNodeID [Maybe Operand]
   | NamedMetadataDefinition String [MetadataNodeID]
   | ModuleInlineAssembly String
-    deriving (Eq, Read, Show)
+    deriving (Eq, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/docs/LangRef.html#modulestructure>
 data Module = 
@@ -41,7 +43,7 @@ data Module =
     moduleTargetTriple :: Maybe String,
     moduleDefinitions :: [Definition]
   } 
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | helper for making 'Module's
 defaultModule = 

--- a/llvm-general-pure/src/LLVM/General/AST/AddrSpace.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/AddrSpace.hs
@@ -1,8 +1,9 @@
 -- | Pointers exist in Address Spaces 
 module LLVM.General.AST.AddrSpace where
 
+import Data.Data
 import Data.Word
 
 -- | See <http://llvm.org/docs/LangRef.html#pointer-type>
 data AddrSpace = AddrSpace Word32
-   deriving (Eq, Ord, Read, Show)
+   deriving (Eq, Ord, Read, Show, Typeable, Data)

--- a/llvm-general-pure/src/LLVM/General/AST/Attribute.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Attribute.hs
@@ -1,6 +1,7 @@
 -- | Module to allow importing 'Attribute' distinctly qualified.
 module LLVM.General.AST.Attribute where
 
+import Data.Data
 import Data.Word
 
 -- | <http://llvm.org/docs/LangRef.html#parameter-attributes>
@@ -13,7 +14,7 @@ data ParameterAttribute
     | ByVal
     | NoCapture
     | Nest
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/docs/LangRef.html#function-attributes>
 data FunctionAttribute
@@ -35,4 +36,4 @@ data FunctionAttribute
     | ReturnsTwice
     | UWTable
     | NonLazyBind
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)

--- a/llvm-general-pure/src/LLVM/General/AST/Constant.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Constant.hs
@@ -3,6 +3,7 @@ module LLVM.General.AST.Constant where
 
 import Data.Word (Word32)
 import Data.Bits ((.|.), (.&.), complement, testBit, shiftL)
+import Data.Data
 
 import LLVM.General.AST.Type
 import LLVM.General.AST.Name
@@ -205,7 +206,7 @@ data Constant
         element :: Constant,
         indices' :: [Word32]
       }
-    deriving (Eq, Ord, Read, Show)
+    deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 
 -- | Since LLVM types don't include signedness, there's ambiguity in interpreting

--- a/llvm-general-pure/src/LLVM/General/AST/DataLayout.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/DataLayout.hs
@@ -2,6 +2,7 @@
 module LLVM.General.AST.DataLayout where
 
 import Data.Word
+import Data.Data
 
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -11,14 +12,14 @@ import LLVM.General.AST.AddrSpace
 
 -- | Little Endian is the one true way :-). Sadly, we must support the infidels.
 data Endianness = LittleEndian | BigEndian
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | An AlignmentInfo describes how a given type must and would best be aligned
 data AlignmentInfo = AlignmentInfo {
     abiAlignment :: Word32,
     preferredAlignment :: Maybe Word32
   }
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | A type of type for which 'AlignmentInfo' may be specified
 data AlignType
@@ -27,7 +28,7 @@ data AlignType
   | FloatAlign
   | AggregateAlign
   | StackAlign
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | a description of the various data layout properties which may be used during
 -- optimization
@@ -38,7 +39,7 @@ data DataLayout = DataLayout {
     typeLayouts :: Map (AlignType, Word32) AlignmentInfo,
     nativeSizes :: Maybe (Set Word32)
   }
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | a 'DataLayout' which specifies nothing
 defaultDataLayout = DataLayout {

--- a/llvm-general-pure/src/LLVM/General/AST/Float.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Float.hs
@@ -4,6 +4,7 @@ module LLVM.General.AST.Float where
 
 import Prelude as P
 import Data.Word (Word16, Word64)
+import Data.Data
 
 -- | A type summing up the various float types.
 -- N.B. Note that in the constructors with multiple fields, the lower significance bits are on the right
@@ -15,5 +16,5 @@ data SomeFloat
   | Quadruple Word64 Word64
   | X86_FP80 Word16 Word64
   | PPC_FP128 Word64 Word64
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 

--- a/llvm-general-pure/src/LLVM/General/AST/Global.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Global.hs
@@ -2,6 +2,7 @@
 module LLVM.General.AST.Global where
 
 import Data.Word
+import Data.Data
 
 import LLVM.General.AST.Name
 import LLVM.General.AST.Type
@@ -52,17 +53,17 @@ data Global
         garbageCollectorName :: Maybe String,
         basicBlocks :: [BasicBlock]
       }
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | 'Parameter's for 'Function's
 data Parameter = Parameter Type Name [A.ParameterAttribute]
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/doxygen/classllvm_1_1BasicBlock.html>
 -- LLVM code in a function is a sequence of 'BasicBlock's each with a label,
 -- some instructions, and a terminator.
 data BasicBlock = BasicBlock Name [Named Instruction] (Named Terminator)
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | helper for making 'GlobalVariable's
 globalVariableDefaults :: Global

--- a/llvm-general-pure/src/LLVM/General/AST/InlineAssembly.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/InlineAssembly.hs
@@ -24,4 +24,4 @@ data InlineAssembly
       alignStack :: Bool,
       dialect :: Dialect
     }
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)

--- a/llvm-general-pure/src/LLVM/General/AST/Instruction.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Instruction.hs
@@ -63,7 +63,7 @@ data Terminator
   | Unreachable {
       metadata' :: InstructionMetadata
     }
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/docs/LangRef.html#atomic-memory-ordering-constraints>
 -- <http://llvm.org/docs/Atomics.html>
@@ -81,13 +81,13 @@ data Atomicity = Atomicity {
   crossThread :: Bool, -- ^ <http://llvm.org/docs/LangRef.html#singlethread>
   memoryOrdering :: MemoryOrdering
  }
- deriving (Eq, Ord, Read, Show)
+ deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | For the redoubtably complex 'LandingPad' instruction
 data LandingPadClause
     = Catch Constant
     | Filter Constant
-    deriving (Eq, Ord, Read, Show)
+    deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | non-terminator instructions:
 -- <http://llvm.org/docs/LangRef.html#binaryops>
@@ -381,11 +381,11 @@ data Instruction
       clauses :: [LandingPadClause],
       metadata :: InstructionMetadata 
     }
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)
 
 -- | Instances of instructions may be given a name, allowing their results to be referenced as 'Operand's.
 -- Sometimes instructions - e.g. a call to a function returning void - don't need names.
 data Named a 
   = Name := a
   | Do a
-  deriving (Eq, Read, Show)
+  deriving (Eq, Read, Show, Typeable, Data)

--- a/llvm-general-pure/src/LLVM/General/AST/Name.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Name.hs
@@ -1,6 +1,8 @@
 -- | Names as used in LLVM IR
 module LLVM.General.AST.Name where
 
+import Data.Data
+
 import Data.Word
 
 {- |
@@ -27,5 +29,5 @@ which they are used.
 data Name 
     = Name String -- ^ a string name 
     | UnName Word -- ^ a number for a nameless thing
-   deriving (Eq, Ord, Read, Show)
+   deriving (Eq, Ord, Read, Show, Typeable, Data)
 

--- a/llvm-general-pure/src/LLVM/General/AST/Operand.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Operand.hs
@@ -1,6 +1,8 @@
 -- | A type to represent operands to LLVM 'LLVM.General.AST.Instruction.Instruction's
 module LLVM.General.AST.Operand where
-  
+
+import Data.Data
+
 import Data.Word
 
 import LLVM.General.AST.Name
@@ -11,13 +13,13 @@ import LLVM.General.AST.InlineAssembly
 -- Note this is different from "named metadata", which are represented with
 -- 'LLVM.General.AST.NamedMetadataDefinition'.
 newtype MetadataNodeID = MetadataNodeID Word
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/docs/LangRef.html#metadata>
 data MetadataNode 
   = MetadataNode [Maybe Operand]
   | MetadataNodeReference MetadataNodeID
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | An 'Operand' is roughly that which is an argument to an 'LLVM.General.AST.Instruction.Instruction'
 data Operand 
@@ -27,7 +29,7 @@ data Operand
   | ConstantOperand Constant
   | MetadataStringOperand String
   | MetadataNodeOperand MetadataNode
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | The 'LLVM.General.AST.Instruction.Call' instruction is special: the callee can be inline assembly
 type CallableOperand  = Either InlineAssembly Operand

--- a/llvm-general-pure/src/LLVM/General/AST/Type.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Type.hs
@@ -6,6 +6,8 @@ import LLVM.General.AST.Name
 
 import Data.Word (Word32, Word64)
 
+import Data.Data
+
 -- | LLVM supports some special formats floating point format. This type is to distinguish those format.
 -- I believe it's treated as a format for "a" float, as opposed to a vector of two floats, because
 -- its intended usage is to represent a single number with a combined significand.
@@ -13,7 +15,7 @@ data FloatingPointFormat
   = IEEE
   | DoubleExtended
   | PairOfFloats
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/docs/LangRef.html#type-system>
 data Type
@@ -37,4 +39,4 @@ data Type
   | NamedTypeReference Name
   -- | <http://llvm.org/docs/LangRef.html#metadata-type>
   | MetadataType -- only to be used as a parameter type for a few intrinsics
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Typeable, Data)


### PR DESCRIPTION
I work currently on a QuasiQuoting Library for llvm-general. To do the actual quoting in a sane way, I need Data instances for the whole AST. This will ultimately help with #65
