### PR TITLE
add dataLayout and targetMachine to CuratedPassSetSpec

### DIFF
--- a/llvm-general/src/LLVM/General/Internal/FFI/PassManager.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/PassManager.hs
@@ -129,3 +129,9 @@ foreign import ccall unsafe "LLVMPassManagerBuilderPopulateLTOPassManager" passM
 
 foreign import ccall unsafe "LLVM_General_PassManagerBuilderSetLibraryInfo" passManagerBuilderSetLibraryInfo ::
     Ptr PassManagerBuilder -> Ptr TargetLibraryInfo -> IO ()
+
+foreign import ccall unsafe "LLVM_General_PassManagerBuilderSetLoopVectorize" passManagerBuilderSetLoopVectorize ::
+    Ptr PassManagerBuilder -> LLVMBool -> IO ()
+
+foreign import ccall unsafe "LLVM_General_PassManagerBuilderSetSLPVectorize" passManagerBuilderSetSLPVectorize ::
+    Ptr PassManagerBuilder -> LLVMBool -> IO ()

--- a/llvm-general/src/LLVM/General/Internal/FFI/PassManagerC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/PassManagerC.cpp
@@ -256,4 +256,18 @@ LLVM_General_PassManagerBuilderSetLibraryInfo(
   unwrap(PMB)->LibraryInfo = new TargetLibraryInfo(*unwrap(l));
 }
 
+void LLVM_General_PassManagerBuilderSetLoopVectorize(
+    LLVMPassManagerBuilderRef PMB,
+    LLVMBool runLoopVectorization
+) {
+  unwrap(PMB)->LoopVectorize = runLoopVectorization;
+}
+
+void LLVM_General_PassManagerBuilderSetSLPVectorize(
+    LLVMPassManagerBuilderRef PMB,
+    LLVMBool runSLPVectorization
+) {
+  unwrap(PMB)->SLPVectorize = runSLPVectorization;
+}
+
 }

--- a/llvm-general/src/LLVM/General/Internal/PassManager.hs
+++ b/llvm-general/src/LLVM/General/Internal/PassManager.hs
@@ -54,6 +54,8 @@ data PassSetSpec
       sizeLevel :: Maybe Word,
       unitAtATime :: Maybe Bool,
       simplifyLibCalls :: Maybe Bool,
+      loopVectorize :: Maybe Bool,
+      slpVectorize :: Maybe Bool,
       useInlinerWithThreshold :: Maybe Word,
       dataLayout :: Maybe DataLayout,
       targetLibraryInfo :: Maybe TargetLibraryInfo,
@@ -66,6 +68,8 @@ defaultCuratedPassSetSpec = CuratedPassSetSpec {
   sizeLevel = Nothing,
   unitAtATime = Nothing,
   simplifyLibCalls = Nothing,
+  loopVectorize = Nothing,
+  slpVectorize = Nothing,
   useInlinerWithThreshold = Nothing,
   dataLayout = Nothing,
   targetLibraryInfo = Nothing,
@@ -99,6 +103,8 @@ createPassManager pss = flip runAnyContT return $ do
         handleOption FFI.passManagerBuilderSetDisableUnitAtATime (liftM not . unitAtATime)
         handleOption FFI.passManagerBuilderSetDisableSimplifyLibCalls (liftM not . simplifyLibCalls)
         handleOption FFI.passManagerBuilderUseInlinerWithThreshold useInlinerWithThreshold
+        handleOption FFI.passManagerBuilderSetLoopVectorize loopVectorize
+        handleOption FFI.passManagerBuilderSetLoopVectorize slpVectorize
         FFI.passManagerBuilderPopulateModulePassManager b pm
     PassSetSpec ps dl tli tm' -> do
       let tm = maybe nullPtr (\(TargetMachine tm) -> tm) tm'


### PR DESCRIPTION
Having DataLayout and TargetMachine is important for certain optimizations.

While testing I stumbled on another issue though. If I set optlevel=Just 3 I get a different set of flags then with opt -O3.

curatedPassSetSpec:

```
-notti -basictti -x86tti -no-aa -tbaa -targetlibinfo -basicaa -globalopt -ipsccp -deadargelim -instcombine -simplifycfg -basiccg -prune-eh -functionattrs -argpromotion -sroa -domtree -early-cse -lazy-value-info -jump-threading -correlated-propagation -simplifycfg -instcombine -tailcallelim -simplifycfg -reassociate -domtree -loops -loop-simplify -lcssa -loop-rotate -licm -lcssa -loop-unswitch -instcombine -scalar-evolution -loop-simplify -lcssa -indvars -loop-idiom -loop-deletion -loop-unroll -memdep -gvn -memdep -memcpyopt -sccp -instcombine -lazy-value-info -jump-threading -correlated-propagation -domtree -memdep -dse -adce -simplifycfg -instcombine -strip-dead-prototypes -globaldce -constmerge
```

opt -O3:

```
Pass Arguments:  -no-aa -tbaa -targetlibinfo -basicaa -notti -preverify -domtree -verify -simplifycfg -domtree -sroa -early-cse -lower-expect
Pass Arguments:  -targetlibinfo -no-aa -tbaa -basicaa -notti -globalopt -ipsccp -deadargelim -instcombine -simplifycfg -basiccg -prune-eh -inline-cost -inline -functionattrs -argpromotion -sroa -domtree -early-cse -lazy-value-info -jump-threading -correlated-propagation -simplifycfg -instcombine -tailcallelim -simplifycfg -reassociate -domtree -loops -loop-simplify -lcssa -loop-rotate -licm -lcssa -loop-unswitch -instcombine -scalar-evolution -loop-simplify -lcssa -indvars -loop-idiom -loop-deletion -loop-unroll -memdep -gvn -memdep -memcpyopt -sccp -instcombine -lazy-value-info -jump-threading -correlated-propagation -domtree -memdep -dse -loops -scalar-evolution -slp-vectorizer -adce -simplifycfg -instcombine -barrier -domtree -loops -loop-simplify -lcssa -scalar-evolution -loop-simplify -lcssa -loop-vectorize -instcombine -simplifycfg -strip-dead-prototypes -globaldce -constmerge -preverify -domtree -verify -print-module
```

It doesn't do any vectorization.
