### PR TITLE
allow linking libc++ as well as libstdc++ 

### DIFF
--- a/llvm-general/llvm-general.cabal
+++ b/llvm-general/llvm-general.cabal
@@ -48,6 +48,11 @@ flag debug
   description: compile C(++) shims with debug info for ease of troubleshooting
   default: False
 
+flag lib-cpp
+  description: Link the C(++) shims with libc++ rather than libstdc++
+  default: False
+  manual: True
+
 library
   build-tools: llvm-config
   ghc-options: -fwarn-unused-imports
@@ -63,7 +68,11 @@ library
     array >= 0.4.0.0,
     setenv >= 0.1.0,
     llvm-general-pure == 3.4.4.0
-  extra-libraries: stdc++
+
+  if(!flag(lib-cpp))
+    extra-libraries: stdc++
+  if (flag(lib-cpp))
+    extra-libraries: c++
   hs-source-dirs: src
   extensions:
     TupleSections


### PR DESCRIPTION
This has been previous discussed as a first step towards making it easier to install when LLVM is built with a c++ that uses libC++ rather than libstdc++
