### PR TITLE
filter out llvm-config revision in --version

### DIFF
--- a/llvm-general/Setup.hs
+++ b/llvm-general/Setup.hs
@@ -22,7 +22,7 @@ import Distribution.System
 -- without checking they're already defined and so causes warnings.
 uncheckedHsFFIDefines = ["__STDC_LIMIT_MACROS"]
 
-llvmVersion = Version [3,5] []
+llvmVersion = Version [3,6] []
 
 llvmConfigNames = [
   "llvm-config-" ++ (intercalate "." . map show . versionBranch $ llvmVersion),

--- a/llvm-general/llvm-general.cabal
+++ b/llvm-general/llvm-general.cabal
@@ -1,5 +1,5 @@
 name: llvm-general
-version: 3.5.0.0
+version: 3.6.0.0
 license: BSD3
 license-file: LICENSE
 author: Benjamin S.Scarlet <fgthb0@greynode.net>


### PR DESCRIPTION
e.g.

```
>llvm-config --version
3.5.r209120
```

it fixes setup process for "r versions"
