### PR TITLE
Metadata 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 .DS_Store
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work

--- a/llvm-general-pure/src/LLVM/General/AST.hs
+++ b/llvm-general-pure/src/LLVM/General/AST.hs
@@ -31,7 +31,7 @@ import qualified LLVM.General.AST.COMDAT as COMDAT
 data Definition 
   = GlobalDefinition Global
   | TypeDefinition Name (Maybe Type)
-  | MetadataNodeDefinition MetadataNodeID [Maybe Operand]
+  | MetadataNodeDefinition MetadataNodeID [Maybe Metadata]
   | NamedMetadataDefinition String [MetadataNodeID]
   | ModuleInlineAssembly String
   | FunctionAttributes A.GroupID [A.FunctionAttribute]

--- a/llvm-general-pure/src/LLVM/General/AST/Operand.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Operand.hs
@@ -20,10 +20,11 @@ data MetadataNode
   | MetadataNodeReference MetadataNodeID
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
+-- | <http://llvm.org/docs/LangRef.html#metadata>
 data Metadata
-  = MDString String
-  | MDNode MetadataNode
-  | MDValue Operand
+  = MDString String -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1MDNode.html>
+  | MDNode MetadataNode -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1MDNode.html>
+  | MDValue Operand -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1ValueAsMetadata.html>
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | An 'Operand' is roughly that which is an argument to an 'LLVM.General.AST.Instruction.Instruction'

--- a/llvm-general-pure/src/LLVM/General/AST/Operand.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Operand.hs
@@ -32,8 +32,6 @@ data Operand
   = LocalReference Type Name
   -- | 'Constant's include 'LLVM.General.AST.Constant.GlobalReference', for \@foo
   | ConstantOperand Constant
-  -- MetadataStringOperand String
-  -- MetadataNodeOperand MetadataNode
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | The 'LLVM.General.AST.Instruction.Call' instruction is special: the callee can be inline assembly

--- a/llvm-general-pure/src/LLVM/General/AST/Operand.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Operand.hs
@@ -16,8 +16,14 @@ newtype MetadataNodeID = MetadataNodeID Word
 
 -- | <http://llvm.org/docs/LangRef.html#metadata>
 data MetadataNode 
-  = MetadataNode [Maybe Operand]
+  = MetadataNode [Maybe Metadata]
   | MetadataNodeReference MetadataNodeID
+  deriving (Eq, Ord, Read, Show, Typeable, Data)
+
+data Metadata
+  = MDString String
+  | MDNode MetadataNode
+  | MDValue Operand
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | An 'Operand' is roughly that which is an argument to an 'LLVM.General.AST.Instruction.Instruction'
@@ -26,8 +32,8 @@ data Operand
   = LocalReference Type Name
   -- | 'Constant's include 'LLVM.General.AST.Constant.GlobalReference', for \@foo
   | ConstantOperand Constant
-  | MetadataStringOperand String
-  | MetadataNodeOperand MetadataNode
+  -- MetadataStringOperand String
+  -- MetadataNodeOperand MetadataNode
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | The 'LLVM.General.AST.Instruction.Call' instruction is special: the callee can be inline assembly

--- a/llvm-general-pure/src/LLVM/General/AST/Operand.hs
+++ b/llvm-general-pure/src/LLVM/General/AST/Operand.hs
@@ -32,6 +32,7 @@ data Operand
   = LocalReference Type Name
   -- | 'Constant's include 'LLVM.General.AST.Constant.GlobalReference', for \@foo
   | ConstantOperand Constant
+  | MetadataOperand Metadata
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | The 'LLVM.General.AST.Instruction.Call' instruction is special: the callee can be inline assembly

--- a/llvm-general-pure/src/LLVM/General/PrettyPrint.hs
+++ b/llvm-general-pure/src/LLVM/General/PrettyPrint.hs
@@ -49,6 +49,7 @@ fmap concat $ mapM makePrettyShowInstance [
   ''A.Operand,
   ''A.MetadataNodeID,
   ''A.MetadataNode,
+  ''A.Metadata,
   ''A.Type,
   ''A.Name,
   ''A.Global,

--- a/llvm-general-pure/test/LLVM/General/Test/PrettyPrint.hs
+++ b/llvm-general-pure/test/LLVM/General/Test/PrettyPrint.hs
@@ -78,13 +78,14 @@ tests = testGroup "PrettyPrint" [
             \            A.metadata' = []\n\
             \          }\n\
             \        )\n\
-            \      ]\n\
+            \      ],\n\
+            \      A.G.personalityFunction = Nothing\n\
             \    }\n\
             \  ]\n\
             \}"
     showPretty ast @?= s,
   testCase "imports" $ do
-    imports defaultPrefixScheme @?= 
+    imports defaultPrefixScheme @?=
       "import Data.Either\n\
       \import qualified Data.Map as Map\n\
       \import Data.Maybe\n\
@@ -109,4 +110,4 @@ tests = testGroup "PrettyPrint" [
       \import qualified LLVM.General.AST.Type as A\n\
       \import qualified LLVM.General.AST.Visibility as A.V\n"
  ]
-  
+

--- a/llvm-general/src/LLVM/General/Internal/FFI/Instruction.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/Instruction.hs
@@ -137,7 +137,7 @@ foreign import ccall unsafe "LLVM_General_GetNumClauses" getNumClauses ::
 foreign import ccall unsafe "LLVM_General_GetClause" getClause ::
   Ptr Instruction -> CUInt -> IO (Ptr Constant)
 
-foreign import ccall unsafe "LLVMSetMetadata" setMetadata ::
+foreign import ccall unsafe "LLVM_General_SetMetadata" setMetadata ::
   Ptr Instruction -> MDKindID -> Ptr MDNode -> IO ()
 
 foreign import ccall unsafe "LLVM_General_GetMetadata" getMetadata ::

--- a/llvm-general/src/LLVM/General/Internal/FFI/InstructionC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/InstructionC.cpp
@@ -266,6 +266,15 @@ void LLVM_General_GetIndirectBrDests(
 		*dests = wrap(ib->getDestination(i));
 }
 
+inline Metadata **unwrap(LLVMMetadataRef *Vals) {
+  return reinterpret_cast<Metadata**>(Vals);
+}
+
+void LLVM_General_SetMetadata(LLVMValueRef Inst, unsigned KindID, LLVMMetadataRef MD) {
+  MDNode *N = MD ? unwrap<MDNode>(MD) : nullptr;
+  unwrap<Instruction>(Inst)->setMetadata(KindID, N);
+}
+
 unsigned LLVM_General_GetMetadata(
 	LLVMValueRef i,
 	unsigned *kinds,

--- a/llvm-general/src/LLVM/General/Internal/FFI/InstructionC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/InstructionC.cpp
@@ -266,13 +266,13 @@ void LLVM_General_GetIndirectBrDests(
 		*dests = wrap(ib->getDestination(i));
 }
 
-inline Metadata **unwrap(LLVMMetadataRef *Vals) {
-  return reinterpret_cast<Metadata**>(Vals);
+inline Metadata **unwrap(LLVMMetadataRef *vals) {
+    return reinterpret_cast<Metadata**>(vals);
 }
 
-void LLVM_General_SetMetadata(LLVMValueRef Inst, unsigned KindID, LLVMMetadataRef MD) {
-  MDNode *N = MD ? unwrap<MDNode>(MD) : nullptr;
-  unwrap<Instruction>(Inst)->setMetadata(KindID, N);
+void LLVM_General_SetMetadata(LLVMValueRef inst, unsigned kindID, LLVMMetadataRef md) {
+    MDNode *N = md ? unwrap<MDNode>(md) : nullptr;
+    unwrap<Instruction>(inst)->setMetadata(kindID, N);
 }
 
 unsigned LLVM_General_GetMetadata(

--- a/llvm-general/src/LLVM/General/Internal/FFI/Metadata.hpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/Metadata.hpp
@@ -4,4 +4,8 @@
 namespace llvm {
 typedef struct LLVMOpaqueMetadata *LLVMMetadataRef;
 DEFINE_ISA_CONVERSION_FUNCTIONS(Metadata, LLVMMetadataRef)
+
+inline Metadata **unwrap(LLVMMetadataRef *Vals) {
+  return reinterpret_cast<Metadata**>(Vals);
+}
 }

--- a/llvm-general/src/LLVM/General/Internal/FFI/Metadata.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/Metadata.hs
@@ -14,11 +14,17 @@ import LLVM.General.Internal.FFI.Context
 import LLVM.General.Internal.FFI.PtrHierarchy
 import LLVM.General.Internal.FFI.LLVMCTypes
 
-foreign import ccall unsafe "LLVMIsAMDString" isAMDString ::
-  Ptr Value -> IO (Ptr MDString)
+foreign import ccall unsafe "LLVM_General_IsAMDString" isAMDString ::
+  Ptr Metadata -> IO (Ptr MDString)
 
-foreign import ccall unsafe "LLVMIsAMDNode" isAMDNode ::
-  Ptr Value -> IO (Ptr MDNode)
+foreign import ccall unsafe "LLVM_General_IsAMDNode" isAMDNode ::
+  Ptr Metadata -> IO (Ptr MDNode)
+
+foreign import ccall unsafe "LLVM_General_IsAMDValue" isAMDValue ::
+  Ptr Metadata -> IO (Ptr MDValue)
+
+foreign import ccall unsafe "LLVM_General_GetMDValue" getMDValue ::
+  Ptr MDValue -> IO (Ptr Value)
 
 foreign import ccall unsafe "LLVMGetMDKindIDInContext" getMDKindIDInContext' ::
   Ptr Context -> Ptr CChar -> CUInt -> IO MDKindID
@@ -28,21 +34,24 @@ getMDKindIDInContext ctx (c, n) = getMDKindIDInContext' ctx c n
 foreign import ccall unsafe "LLVM_General_GetMDKindNames" getMDKindNames ::
   Ptr Context -> Ptr (Ptr CChar) -> Ptr CUInt -> CUInt -> IO CUInt
 
-foreign import ccall unsafe "LLVMMDStringInContext" mdStringInContext' ::
+foreign import ccall unsafe "LLVM_General_MDStringInContext" mdStringInContext' ::
   Ptr Context -> CString -> CUInt -> IO (Ptr MDString)
+
+foreign import ccall unsafe "LLVM_General_MDValue" mdValue ::
+  Ptr Value -> IO (Ptr MDValue)
 
 mdStringInContext ctx (p, n) = mdStringInContext' ctx p n
 
-foreign import ccall unsafe "LLVMGetMDString" getMDString ::
+foreign import ccall unsafe "LLVM_General_GetMDString" getMDString ::
   Ptr MDString -> Ptr CUInt -> IO CString
 
-foreign import ccall unsafe "LLVMMDNodeInContext" createMDNodeInContext' ::
-  Ptr Context -> Ptr (Ptr Value) -> CUInt -> IO (Ptr MDNode)
+foreign import ccall unsafe "LLVM_General_MDNodeInContext" createMDNodeInContext' ::
+  Ptr Context -> Ptr (Ptr Metadata) -> CUInt -> IO (Ptr MDNode)
 
 createMDNodeInContext ctx (n, vs) = createMDNodeInContext' ctx vs n
 
--- foreign import ccall unsafe "LLVM_General_CreateTemporaryMDNodeInContext" createTemporaryMDNodeInContext ::
---   Ptr Context -> IO (Ptr MDNode)
+foreign import ccall unsafe "LLVM_General_CreateTemporaryMDNodeInContext" createTemporaryMDNodeInContext ::
+  Ptr Context -> IO (Ptr MDNode)
 
 foreign import ccall unsafe "LLVM_General_DestroyTemporaryMDNode" destroyTemporaryMDNode ::
   Ptr MDNode -> IO ()
@@ -50,11 +59,8 @@ foreign import ccall unsafe "LLVM_General_DestroyTemporaryMDNode" destroyTempora
 foreign import ccall unsafe "LLVM_General_GetMDNodeNumOperands" getMDNodeNumOperands ::
   Ptr MDNode -> IO CUInt
 
-foreign import ccall unsafe "LLVMGetMDNodeOperands" getMDNodeOperands ::
-  Ptr MDNode -> Ptr (Ptr Value) -> IO ()
-
--- foreign import ccall unsafe "LLVM_General_MDNodeIsFunctionLocal" mdNodeIsFunctionLocal ::
---   Ptr MDNode -> IO LLVMBool
+foreign import ccall unsafe "LLVM_General_GetMDNodeOperands" getMDNodeOperands ::
+  Ptr MDNode -> Ptr (Ptr Metadata) -> IO ()
 
 foreign import ccall unsafe "LLVM_General_GetNamedMetadataName" getNamedMetadataName ::
   Ptr NamedMetadata -> Ptr CUInt -> IO (Ptr CChar)
@@ -67,5 +73,8 @@ foreign import ccall unsafe "LLVM_General_GetNamedMetadataOperands" getNamedMeta
 
 foreign import ccall unsafe "LLVM_General_NamedMetadataAddOperands" namedMetadataAddOperands' ::
   Ptr NamedMetadata -> Ptr (Ptr MDNode) -> CUInt -> IO ()
+
+foreign import ccall unsafe "LLVM_General_MetadataReplaceAllUsesWith" metadataReplaceAllUsesWith ::
+  Ptr MDNode -> Ptr Metadata -> IO ()
 
 namedMetadataAddOperands nm (n, vs) = namedMetadataAddOperands' nm vs n

--- a/llvm-general/src/LLVM/General/Internal/FFI/Metadata.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/Metadata.hs
@@ -23,8 +23,14 @@ foreign import ccall unsafe "LLVM_General_IsAMDNode" isAMDNode ::
 foreign import ccall unsafe "LLVM_General_IsAMDValue" isAMDValue ::
   Ptr Metadata -> IO (Ptr MDValue)
 
+foreign import ccall unsafe "LLVM_General_IsAMetadataOperand" isAMetadataOperand ::
+  Ptr Value -> IO (Ptr MetadataAsVal)
+
 foreign import ccall unsafe "LLVM_General_GetMDValue" getMDValue ::
   Ptr MDValue -> IO (Ptr Value)
+
+foreign import ccall unsafe "LLVM_General_GetMetadataOperand" getMetadataOperand ::
+  Ptr MetadataAsVal -> IO (Ptr Metadata)
 
 foreign import ccall unsafe "LLVMGetMDKindIDInContext" getMDKindIDInContext' ::
   Ptr Context -> Ptr CChar -> CUInt -> IO MDKindID
@@ -39,6 +45,9 @@ foreign import ccall unsafe "LLVM_General_MDStringInContext" mdStringInContext' 
 
 foreign import ccall unsafe "LLVM_General_MDValue" mdValue ::
   Ptr Value -> IO (Ptr MDValue)
+
+foreign import ccall unsafe "LLVM_General_MetadataOperand" metadataOperand ::
+  Ptr Context -> Ptr Metadata -> IO (Ptr Value)
 
 mdStringInContext ctx (p, n) = mdStringInContext' ctx p n
 

--- a/llvm-general/src/LLVM/General/Internal/FFI/MetadataC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/MetadataC.cpp
@@ -38,6 +38,10 @@ LLVMMetadataRef LLVM_General_MDValue(LLVMValueRef v) {
     return wrap(ValueAsMetadata::get(unwrap(v)));
 }
 
+LLVMValueRef LLVM_General_MetadataOperand(LLVMContextRef c, LLVMMetadataRef md) {
+    return wrap(MetadataAsValue::get(*unwrap(c), unwrap(md)));
+}
+
 LLVMMetadataRef LLVM_General_IsAMDNode(LLVMMetadataRef md) {
     if (isa<MDNode>(unwrap(md))) {
         return md;
@@ -47,6 +51,10 @@ LLVMMetadataRef LLVM_General_IsAMDNode(LLVMMetadataRef md) {
 
 LLVMValueRef LLVM_General_GetMDValue(LLVMMetadataRef md) {
     return wrap(unwrap<ValueAsMetadata>(md)->getValue());
+}
+
+LLVMMetadataRef LLVM_General_GetMetadataOperand(LLVMValueRef val) {
+    return wrap(unwrap<MetadataAsValue>(val)->getMetadata());
 }
 
 LLVMMetadataRef LLVM_General_MDNodeInContext(LLVMContextRef C,
@@ -62,6 +70,15 @@ LLVMMetadataRef LLVM_General_IsAMDValue(LLVMMetadataRef md) {
     }
     return nullptr;
 }
+
+
+LLVMValueRef LLVM_General_IsAMetadataOperand(LLVMValueRef val) {
+    if (isa<MetadataAsValue>(unwrap(val))) {
+        return val;
+    }
+    return nullptr;
+}
+
 
 unsigned LLVM_General_GetMDKindNames(
 	LLVMContextRef c,

--- a/llvm-general/src/LLVM/General/Internal/FFI/MetadataC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/MetadataC.cpp
@@ -132,13 +132,7 @@ LLVMMetadataRef LLVM_General_CreateTemporaryMDNodeInContext(LLVMContextRef c) {
 }
 
 void LLVM_General_DestroyTemporaryMDNode(LLVMMetadataRef v) {
-    std::cerr << "C: destroy temporary: " << v << "\n";
-    MDNode* n = unwrap<MDNode>(v);
-    std::cerr << "unwrapped\n";
-    std::cerr << "temp? " << n->isTemporary() << "\n";
-    n->print(llvm::errs());
-	MDNode::deleteTemporary(unwrap<MDNode>(v));
-    std::cerr << "C: destroyed temporary\n";
+    MDNode::deleteTemporary(unwrap<MDNode>(v));
 }
 
 void LLVM_General_GetMDNodeOperands(LLVMMetadataRef MD, LLVMMetadataRef *Dest) {

--- a/llvm-general/src/LLVM/General/Internal/FFI/MetadataC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/MetadataC.cpp
@@ -20,18 +20,18 @@ LLVMMetadataRef LLVM_General_IsAMDString(LLVMMetadataRef md) {
     return nullptr;
 }
 
-LLVMMetadataRef LLVM_General_MDStringInContext(LLVMContextRef C,
-                                               const char *Str, unsigned SLen) {
-  return wrap(MDString::get(*unwrap(C), StringRef(Str, SLen)));
+LLVMMetadataRef LLVM_General_MDStringInContext(LLVMContextRef c,
+                                               const char *str, unsigned slen) {
+    return wrap(MDString::get(*unwrap(c), StringRef(str, slen)));
 }
 
-const char *LLVM_General_GetMDString(LLVMMetadataRef MD, unsigned* Len) {
-    if (const MDString *S = dyn_cast<MDString>(unwrap(MD))) {
-      *Len = S->getString().size();
+const char *LLVM_General_GetMDString(LLVMMetadataRef md, unsigned* len) {
+    if (const MDString *S = dyn_cast<MDString>(unwrap(md))) {
+      *len = S->getString().size();
       return S->getString().data();
     }
-  *Len = 0;
-  return nullptr;
+    *len = 0;
+    return nullptr;
 }
 
 LLVMMetadataRef LLVM_General_MDValue(LLVMValueRef v) {
@@ -57,11 +57,10 @@ LLVMMetadataRef LLVM_General_GetMetadataOperand(LLVMValueRef val) {
     return wrap(unwrap<MetadataAsValue>(val)->getMetadata());
 }
 
-LLVMMetadataRef LLVM_General_MDNodeInContext(LLVMContextRef C,
-                                             LLVMMetadataRef *MDs,
-                                             unsigned Count) {
-  return wrap(
-      MDNode::get(*unwrap(C), ArrayRef<Metadata *>(unwrap(MDs), Count)));
+LLVMMetadataRef LLVM_General_MDNodeInContext(LLVMContextRef c,
+                                             LLVMMetadataRef *mds,
+                                             unsigned count) {
+    return wrap(MDNode::get(*unwrap(c), ArrayRef<Metadata *>(unwrap(mds), count)));
 }
 
 LLVMMetadataRef LLVM_General_IsAMDValue(LLVMMetadataRef md) {
@@ -135,17 +134,17 @@ void LLVM_General_DestroyTemporaryMDNode(LLVMMetadataRef v) {
     MDNode::deleteTemporary(unwrap<MDNode>(v));
 }
 
-void LLVM_General_GetMDNodeOperands(LLVMMetadataRef MD, LLVMMetadataRef *Dest) {
-    const auto *N = cast<MDNode>(unwrap(MD));
+void LLVM_General_GetMDNodeOperands(LLVMMetadataRef md, LLVMMetadataRef *dest) {
+    const auto *N = cast<MDNode>(unwrap(md));
     const unsigned numOperands = N->getNumOperands();
     for (unsigned i = 0; i < numOperands; i++)
-        Dest[i] = wrap(N->getOperand(i));
+        dest[i] = wrap(N->getOperand(i));
 }
 
-void LLVM_General_MetadataReplaceAllUsesWith(LLVMMetadataRef MD, LLVMMetadataRef New) {
-  auto *Node = unwrap<MDNode>(MD);
-  Node->replaceAllUsesWith(unwrap<Metadata>(New));
-  MDNode::deleteTemporary(Node);
+void LLVM_General_MetadataReplaceAllUsesWith(LLVMMetadataRef md, LLVMMetadataRef replacement) {
+    auto *Node = unwrap<MDNode>(md);
+    Node->replaceAllUsesWith(unwrap<Metadata>(replacement));
+    MDNode::deleteTemporary(Node);
 }
 
 }

--- a/llvm-general/src/LLVM/General/Internal/FFI/PtrHierarchy.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/PtrHierarchy.hs
@@ -119,3 +119,8 @@ data Type
 
 -- | <http://llvm.org/doxygen/classllvm_1_1Metadata.html>
 data Metadata
+
+-- | <http://www.llvm.org/docs/doxygen/html/classllvm_1_1MetadataAsValue.html>
+data MetadataAsVal
+
+instance ChildOf Value MetadataAsVal

--- a/llvm-general/src/LLVM/General/Internal/FFI/PtrHierarchy.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/PtrHierarchy.hs
@@ -94,12 +94,17 @@ instance ChildOf Value User
 -- | <http://llvm.org/doxygen/classllvm_1_1MDNode.html>
 data MDNode
 
-instance ChildOf Value MDNode
+instance ChildOf Metadata MDNode
 
 -- | <http://llvm.org/doxygen/classllvm_1_1MDString.html>
 data MDString
 
-instance ChildOf Value MDString
+instance ChildOf Metadata MDString
+
+-- | http://llvm.org/doxygen/classllvm_1_1ValueAsMetadata.html
+data MDValue
+
+instance ChildOf Metadata MDValue
 
 -- | <http://llvm.org/doxygen/classllvm_1_1NamedMDNode.html>
 data NamedMetadata
@@ -112,3 +117,5 @@ instance ChildOf Value InlineAsm
 -- | <http://llvm.org/doxygen/classllvm_1_1Type.html>
 data Type
 
+-- | <http://llvm.org/doxygen/classllvm_1_1Metadata.html>
+data Metadata

--- a/llvm-general/src/LLVM/General/Internal/Module.hs
+++ b/llvm-general/src/LLVM/General/Internal/Module.hs
@@ -245,15 +245,13 @@ withModuleFromAST context@(Context c) (A.Module moduleId dataLayout triple defin
      return . return . return . return . return $ ()
      
    A.MetadataNodeDefinition i os -> return . return $ do
-     error "FIXME: createTemporaryMDNodeInContext"
-     -- t <- liftIO $ FFI.createTemporaryMDNodeInContext c
-     -- defineMDNode i t
-     -- return $ do
-     --   n <- encodeM (A.MetadataNode os)
-     --   liftIO $ FFI.replaceAllUsesWith (FFI.upCast t) (FFI.upCast n)
-     --   defineMDNode i n
-     --   liftIO $ FFI.destroyTemporaryMDNode t
-     --   return $ return ()
+     t <- liftIO $ FFI.createTemporaryMDNodeInContext c
+     defineMDNode i t
+     return $ do
+       n <- encodeM (A.MetadataNode os)
+       liftIO $ FFI.metadataReplaceAllUsesWith (FFI.upCast t) (FFI.upCast n)
+       defineMDNode i n
+       return $ return ()
 
    A.NamedMetadataDefinition n ids -> return . return . return . return $ do
      n <- encodeM n

--- a/llvm-general/src/LLVM/General/Internal/Operand.hs
+++ b/llvm-general/src/LLVM/General/Internal/Operand.hs
@@ -34,19 +34,22 @@ instance DecodeM DecodeAST A.Operand (Ptr FFI.Value) where
      then
       return A.ConstantOperand `ap` decodeM c
      else
-      do
-        mds <- liftIO $ FFI.isAMDString v
-        if mds /= nullPtr 
-         then return A.MetadataStringOperand `ap` decodeM mds
-         else
-           do
-             mdn <- liftIO $ FFI.isAMDNode v
-             if mdn /= nullPtr
-              then return A.MetadataNodeOperand `ap` decodeM mdn
-              else
-                return A.LocalReference 
-                         `ap` (decodeM =<< (liftIO $ FFI.typeOf v))
-                         `ap` getLocalName v
+      do return A.LocalReference
+                   `ap` (decodeM =<< (liftIO $ FFI.typeOf v))
+                   `ap` getLocalName v
+
+instance DecodeM DecodeAST A.Metadata (Ptr FFI.Metadata) where
+  decodeM md = do
+    s <- liftIO $ FFI.isAMDString md
+    if (s /= nullPtr)
+       then A.MDString <$> decodeM s
+       else do n <- liftIO $ FFI.isAMDNode md
+               if (n /= nullPtr)
+                  then A.MDNode <$> decodeM n
+                  else do v <- liftIO $ FFI.isAMDValue md
+                          if (v /= nullPtr)
+                              then A.MDValue <$> decodeM v
+                              else fail "Metadata was not one of [MDString, MDValue, MDNode]"
 
 instance DecodeM DecodeAST A.CallableOperand (Ptr FFI.Value) where
   decodeM v = do
@@ -68,11 +71,16 @@ instance EncodeM EncodeAST A.Operand (Ptr FFI.Value) where
       return lv
     return $ case lv of DefinedValue v -> v; ForwardValue v -> v
 
-  encodeM (A.MetadataStringOperand s) = do
+
+instance EncodeM EncodeAST A.Metadata (Ptr FFI.Metadata) where
+  encodeM (A.MDString s) = do
     Context c <- gets encodeStateContext
     s <- encodeM s
     liftM FFI.upCast $ liftIO $ FFI.mdStringInContext c s
-  encodeM (A.MetadataNodeOperand mdn) = (FFI.upCast :: Ptr FFI.MDNode -> Ptr FFI.Value) <$> encodeM mdn
+  encodeM (A.MDNode mdn) = (FFI.upCast :: Ptr FFI.MDNode -> Ptr FFI.Metadata) <$> encodeM mdn
+  encodeM (A.MDValue v) = do
+     v <- encodeM v
+     liftIO $ FFI.upCast <$> FFI.mdValue v
 
 instance EncodeM EncodeAST A.CallableOperand (Ptr FFI.Value) where
   encodeM (Right o) = encodeM o
@@ -85,12 +93,15 @@ instance EncodeM EncodeAST A.MetadataNode (Ptr FFI.MDNode) where
     liftIO $ FFI.createMDNodeInContext c ops
   encodeM (A.MetadataNodeReference n) = referMDNode n
 
-instance DecodeM DecodeAST [Maybe A.Operand] (Ptr FFI.MDNode) where
+instance DecodeM DecodeAST [Maybe A.Metadata] (Ptr FFI.MDNode) where
   decodeM p = scopeAnyCont $ do
     n <- liftIO $ FFI.getMDNodeNumOperands p
     ops <- allocaArray n
     liftIO $ FFI.getMDNodeOperands p ops
     decodeM (n, ops)
+
+instance DecodeM DecodeAST A.Operand (Ptr FFI.MDValue) where
+  decodeM = decodeM <=< liftIO . FFI.getMDValue
 
 instance DecodeM DecodeAST A.MetadataNode (Ptr FFI.MDNode) where
   decodeM p = scopeAnyCont $ do
@@ -98,9 +109,9 @@ instance DecodeM DecodeAST A.MetadataNode (Ptr FFI.MDNode) where
     -- fl <- decodeM =<< liftIO (FFI.mdNodeIsFunctionLocal p)
     -- if fl
     --  then
-       return A.MetadataNode `ap` decodeM p
-     -- else
-     --   return A.MetadataNodeReference `ap` getMetadataNodeID p
+    --    return A.MetadataNode `ap` decodeM p
+    --  else
+       return A.MetadataNodeReference `ap` getMetadataNodeID p
 
 getMetadataDefinitions :: DecodeAST [A.Definition]
 getMetadataDefinitions = fix $ \continue -> do

--- a/llvm-general/test/LLVM/General/Test/Optimization.hs
+++ b/llvm-general/test/LLVM/General/Test/Optimization.hs
@@ -205,66 +205,66 @@ tests = testGroup "Optimization" [
                     ] }) mIn
       isVectory mOut,
       
-    -- testCase "LoopVectorize" $ do
-    --   let
-    --     mIn = 
-    --       Module {
-    --         moduleName = "<string>",
-    --         moduleDataLayout = Just $ (defaultDataLayout BigEndian) { 
-    --           typeLayouts = Map.singleton (VectorAlign, 128) (AlignmentInfo 128 Nothing)
-    --          },
-    --         moduleTargetTriple = Just "x86_64",
-    --         moduleDefinitions = [
-    --           GlobalDefinition $ globalVariableDefaults {
-    --             G.name = Name "a",
-    --             G.linkage = L.Common,
-    --             G.type' = A.T.ArrayType 2048 i32,
-    --             G.initializer = Just (C.Null (A.T.ArrayType 2048 i32))
-    --            },
-    --           GlobalDefinition $ functionDefaults {
-    --             G.returnType = A.T.void,
-    --             G.name = Name "inc",
-    --             G.functionAttributes = [Left (A.GroupID 0)],
-    --             G.parameters = ([Parameter i32 (Name "n") []], False),
-    --             G.basicBlocks = [
-    --               BasicBlock (UnName 0) [
-    --                 UnName 1 := ICmp IPred.SGT (LocalReference i32 (Name "n")) (ConstantOperand (C.Int 32 0)) []
-    --                ] (Do $ CondBr (LocalReference i1 (UnName 1)) (Name ".lr.ph") (Name "._crit_edge") []),
-    --               BasicBlock (Name ".lr.ph") [
-    --                 Name "indvars.iv" := Phi i64 [ 
-    --                   (ConstantOperand (C.Int 64 0), UnName 0),
-    --                   (LocalReference i64 (Name "indvars.iv.next"), Name ".lr.ph")
-    --                  ] [],
-    --                 UnName 2 := GetElementPtr True (ConstantOperand (C.GlobalReference (A.T.ArrayType 2048 i32) (Name "a"))) [ 
-    --                   ConstantOperand (C.Int 64 0),
-    --                   (LocalReference i64 (Name "indvars.iv"))
-    --                  ] [],
-    --                 UnName 3 := Load False (LocalReference (ptr i32) (UnName 2)) Nothing 4 [],
-    --                 UnName 4 := Trunc (LocalReference i64 (Name "indvars.iv")) i32 [],
-    --                 UnName 5 := Add True False (LocalReference i32 (UnName 3)) (LocalReference i32 (UnName 4)) [],
-    --                 Do $ Store False (LocalReference (ptr i32) (UnName 2)) (LocalReference i32 (UnName 5)) Nothing 4 [],
-    --                 Name "indvars.iv.next" := Add False False (LocalReference i64 (Name "indvars.iv")) (ConstantOperand (C.Int 64 1)) [],
-    --                 Name "lftr.wideiv" := Trunc (LocalReference i64 (Name "indvars.iv.next")) i32 [],
-    --                 Name "exitcond" := ICmp IPred.EQ (LocalReference i32 (Name "lftr.wideiv")) (LocalReference i32 (Name "n")) []
-    --                ] (Do $ CondBr (LocalReference i1 (Name "exitcond")) (Name "._crit_edge") (Name ".lr.ph") []),
-    --               BasicBlock (Name "._crit_edge") [
-    --                ] (Do $ Ret Nothing [])
-    --              ]
-    --            },
-    --           FunctionAttributes (A.GroupID 0) [A.NoUnwind, A.ReadNone, A.UWTable, A.StackProtect]
-    --          ]
-    --        }
-    --   mOut <- do
-    --     let triple = "x86_64"
-    --     (target, _) <- failInIO $ lookupTarget Nothing triple
-    --     withTargetOptions $ \targetOptions -> do
-    --       withTargetMachine target triple "" Map.empty targetOptions R.Default CM.Default CGO.Default $ \tm -> do
-    --         optimize (defaultPassSetSpec { 
-    --                     transforms = [ T.defaultLoopVectorize ],
-    --                     dataLayout = moduleDataLayout mIn,
-    --                     targetMachine = Just tm
-    --                   }) mIn
-    --   isVectory mOut,
+    testCase "LoopVectorize" $ do
+      let
+        mIn = 
+          Module {
+            moduleName = "<string>",
+            moduleDataLayout = Just $ (defaultDataLayout BigEndian) { 
+              typeLayouts = Map.singleton (VectorAlign, 128) (AlignmentInfo 128 Nothing)
+             },
+            moduleTargetTriple = Just "x86_64",
+            moduleDefinitions = [
+              GlobalDefinition $ globalVariableDefaults {
+                G.name = Name "a",
+                G.linkage = L.Common,
+                G.type' = A.T.ArrayType 2048 i32,
+                G.initializer = Just (C.Null (A.T.ArrayType 2048 i32))
+               },
+              GlobalDefinition $ functionDefaults {
+                G.returnType = A.T.void,
+                G.name = Name "inc",
+                G.functionAttributes = [Left (A.GroupID 0)],
+                G.parameters = ([Parameter i32 (Name "n") []], False),
+                G.basicBlocks = [
+                  BasicBlock (UnName 0) [
+                    UnName 1 := ICmp IPred.SGT (LocalReference i32 (Name "n")) (ConstantOperand (C.Int 32 0)) []
+                   ] (Do $ CondBr (LocalReference i1 (UnName 1)) (Name ".lr.ph") (Name "._crit_edge") []),
+                  BasicBlock (Name ".lr.ph") [
+                    Name "indvars.iv" := Phi i64 [ 
+                      (ConstantOperand (C.Int 64 0), UnName 0),
+                      (LocalReference i64 (Name "indvars.iv.next"), Name ".lr.ph")
+                     ] [],
+                    UnName 2 := GetElementPtr True (ConstantOperand (C.GlobalReference (A.T.ArrayType 2048 i32) (Name "a"))) [ 
+                      ConstantOperand (C.Int 64 0),
+                      (LocalReference i64 (Name "indvars.iv"))
+                     ] [],
+                    UnName 3 := Load False (LocalReference (ptr i32) (UnName 2)) Nothing 4 [],
+                    UnName 4 := Trunc (LocalReference i64 (Name "indvars.iv")) i32 [],
+                    UnName 5 := Add True False (LocalReference i32 (UnName 3)) (LocalReference i32 (UnName 4)) [],
+                    Do $ Store False (LocalReference (ptr i32) (UnName 2)) (LocalReference i32 (UnName 5)) Nothing 4 [],
+                    Name "indvars.iv.next" := Add False False (LocalReference i64 (Name "indvars.iv")) (ConstantOperand (C.Int 64 1)) [],
+                    Name "lftr.wideiv" := Trunc (LocalReference i64 (Name "indvars.iv.next")) i32 [],
+                    Name "exitcond" := ICmp IPred.EQ (LocalReference i32 (Name "lftr.wideiv")) (LocalReference i32 (Name "n")) []
+                   ] (Do $ CondBr (LocalReference i1 (Name "exitcond")) (Name "._crit_edge") (Name ".lr.ph") []),
+                  BasicBlock (Name "._crit_edge") [
+                   ] (Do $ Ret Nothing [])
+                 ]
+               },
+              FunctionAttributes (A.GroupID 0) [A.NoUnwind, A.ReadNone, A.UWTable, A.StackProtect]
+             ]
+           }
+      mOut <- do
+        let triple = "x86_64"
+        (target, _) <- failInIO $ lookupTarget Nothing triple
+        withTargetOptions $ \targetOptions -> do
+          withTargetMachine target triple "" Map.empty targetOptions R.Default CM.Default CGO.Default $ \tm -> do
+            optimize (defaultPassSetSpec { 
+                        transforms = [ T.defaultLoopVectorize ],
+                        dataLayout = moduleDataLayout mIn,
+                        targetMachine = Just tm
+                      }) mIn
+      isVectory mOut,
 
     testCase "LowerInvoke" $ do
       -- This test doesn't test much about what LowerInvoke does, just that it seems to work.

--- a/llvm-general/test/LLVM/General/Test/Tests.hs
+++ b/llvm-general/test/LLVM/General/Test/Tests.hs
@@ -25,7 +25,7 @@ tests = testGroup "llvm-general" [
     Global.tests,
     InlineAssembly.tests,
     Instructions.tests,
-    -- Metadata.tests,
+    Metadata.tests,
     Module.tests,
     Optimization.tests,
     Target.tests,


### PR DESCRIPTION
Since the rest of the big PR is merged, this is a smaller PR with the remaining metadata changes (and a fix from @xldenis) to make it easier to see what’s going on.

It mostly works but there are two problems: I’m not sure about the decoding of `MDNode` since the `isFunctionLocal` attribute no longer exists. One of the tests doesn’t work because I still haven’t managed to figure out if this is simply no longer possible or if it just uses some very weird syntax.
