### PR TITLE
Link against the correct stdlib, fixes #77

### DIFF
--- a/llvm-general/llvm-general.cabal
+++ b/llvm-general/llvm-general.cabal
@@ -75,7 +75,6 @@ library
     parsec >= 3.1.3,
     array >= 0.4.0.0,
     llvm-general-pure == 3.8.0.0
-  extra-libraries: stdc++
   hs-source-dirs: src
   extensions:
     NoImplicitPrelude


### PR DESCRIPTION
This also includes the fix for linking against LLVM build with Clang. Excluding `-Wcovered-switch-default` seems pretty safe as this is only a warning and shouldn’t cause any failures when linking.
