### PR TITLE
Don’t pass c++ options to hsc2hs

### DIFF
--- a/llvm-general/llvm-general.cabal
+++ b/llvm-general/llvm-general.cabal
@@ -62,7 +62,6 @@ custom-setup
 library
   build-tools: llvm-config
   ghc-options: -fwarn-unused-imports
-  cc-options: -std=c++11
   build-depends:
     base >= 4.7 && < 5,
     utf8-string >= 0.3.7,


### PR DESCRIPTION
I don’t have access to macOS so I don’t know whether this fixes #169  but at least on archlinux it helps with some of the warnings.
