### PR TITLE
Ignore -fcolor-diagnostics (not a valid gcc arg)

### DIFF
--- a/llvm-general/Setup.hs
+++ b/llvm-general/Setup.hs
@@ -103,10 +103,10 @@ addLLVMToLdLibraryPath configFlags = do
 -- linking against LLVM build with Clang using GCC
 ignoredCxxFlags :: [String]
 ignoredCxxFlags =
-  ["-Wcovered-switch-default"] ++ map ("-D" ++) uncheckedHsFFIDefines
+  ["-Wcovered-switch-default", "-fcolor-diagnostics"] ++ map ("-D" ++) uncheckedHsFFIDefines
 
 ignoredCFlags :: [String]
-ignoredCFlags = ["-Wcovered-switch-default", "-Wdelete-non-virtual-dtor"]
+ignoredCFlags = ["-Wcovered-switch-default", "-Wdelete-non-virtual-dtor", "-fcolor-diagnostics"]
 
 main = do
   let origUserHooks = simpleUserHooks


### PR DESCRIPTION
I’m not completely sure when this argument is used by `llvm` but it is not a valid `gcc` argument so we need to filter it.
