### PR TITLE
OrcJIT API expansion and test fixes

### DIFF
--- a/llvm-general/src/LLVM/General/Internal/FFI/OrcJIT.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/OrcJIT.hs
@@ -34,6 +34,9 @@ foreign import ccall safe "LLVM_General_disposeIRCompileLayer" disposeIRCompileL
 foreign import ccall safe "LLVM_General_IRCompileLayer_findSymbol" findSymbol ::
   Ptr IRCompileLayer -> Ptr DataLayout -> CString -> LLVMBool -> IO (Ptr JITSymbol)
 
+foreign import ccall safe "LLVM_General_IRCompileLayer_findSymbolIn" findSymbolIn ::
+  Ptr IRCompileLayer -> Ptr DataLayout -> Ptr ModuleSetHandle -> CString -> LLVMBool -> IO (Ptr JITSymbol)
+
 foreign import ccall safe "LLVM_General_disposeJITSymbol" disposeSymbol ::
   Ptr JITSymbol -> IO ()
 

--- a/llvm-general/src/LLVM/General/Internal/FFI/OrcJITC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/OrcJITC.cpp
@@ -52,6 +52,14 @@ LLVMJITSymbolRef LLVM_General_IRCompileLayer_findSymbol(
     return new JITSymbol(symbol);
 }
 
+LLVMJITSymbolRef LLVM_General_IRCompileLayer_findSymbolIn(
+    LLVMIRCompileLayerRef compileLayer, LLVMTargetDataRef dataLayout,
+    LLVMModuleSetHandleRef moduleSetHandle,
+    const char *name, LLVMBool exportedSymbolsOnly) {
+  JITSymbol symbol = compileLayer->findSymbolIn(*moduleSetHandle, name, exportedSymbolsOnly);
+    return new JITSymbol(symbol);
+}
+
 void LLVM_General_disposeJITSymbol(LLVMJITSymbolRef symbol) { delete symbol; }
 
 LLVMLambdaResolverRef LLVM_General_createLambdaResolver(

--- a/llvm-general/src/LLVM/General/Internal/OrcJIT.hs
+++ b/llvm-general/src/LLVM/General/Internal/OrcJIT.hs
@@ -172,3 +172,23 @@ withObjectLinkingLayer f =
     FFI.createObjectLinkingLayer
     FFI.disposeObjectLinkingLayer $ \objectLayer ->
       f (ObjectLinkingLayer objectLayer)
+
+createObjectLinkingLayer :: IO ObjectLinkingLayer
+createObjectLinkingLayer = ObjectLinkingLayer <$> FFI.createObjectLinkingLayer
+
+disposeObjectLinkingLayer :: ObjectLinkingLayer -> IO ()
+disposeObjectLinkingLayer (ObjectLinkingLayer oll) =
+  FFI.disposeObjectLinkingLayer oll
+
+createIRCompileLayer :: ObjectLinkingLayer -> TargetMachine -> IO IRCompileLayer
+createIRCompileLayer (ObjectLinkingLayer oll) (TargetMachine tm) = do
+  dl <- FFI.createTargetDataLayout tm
+  cl <- FFI.createIRCompileLayer oll tm
+  cleanup <- newIORef []
+  return (IRCompileLayer cl dl cleanup)
+
+disposeIRCompileLayer :: IRCompileLayer -> IO ()
+disposeIRCompileLayer (IRCompileLayer cl dl cleanup) =
+  do FFI.disposeDataLayout dl
+     FFI.disposeIRCompileLayer cl
+     readIORef cleanup >>= sequence_

--- a/llvm-general/src/LLVM/General/Internal/OrcJIT.hs
+++ b/llvm-general/src/LLVM/General/Internal/OrcJIT.hs
@@ -138,6 +138,14 @@ findSymbol (IRCompileLayer cl dl _) symbol exportedSymbolsOnly = flip runAnyCont
     (FFI.findSymbol cl dl symbol' exportedSymbolsOnly') FFI.disposeSymbol
   decodeM symbol
 
+findSymbolIn :: IRCompileLayer -> ModuleSet -> MangledSymbol -> Bool -> IO JITSymbol
+findSymbolIn (IRCompileLayer cl dl _) (ModuleSet moduleSet) symbol exportedSymbolsOnly = flip runAnyContT return $ do
+  symbol' <- encodeM symbol
+  exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
+  symbol <- anyContToM $ bracket
+    (FFI.findSymbolIn cl dl moduleSet symbol' exportedSymbolsOnly') FFI.disposeSymbol
+  decodeM symbol
+
 addModuleSet :: IRCompileLayer -> [Module] -> SymbolResolver -> IO ModuleSet
 addModuleSet (IRCompileLayer cl dl cleanups) modules resolver = flip runAnyContT return $ do
   resolverAct <- encodeM resolver

--- a/llvm-general/src/LLVM/General/Module.hs
+++ b/llvm-general/src/LLVM/General/Module.hs
@@ -5,6 +5,7 @@ module LLVM.General.Module (
     File(..),
 
     withModuleFromAST,
+    withModuleFromASTForTargetMachine,
     moduleAST,
 
     withModuleFromLLVMAssembly,

--- a/llvm-general/src/LLVM/General/OrcJIT.hs
+++ b/llvm-general/src/LLVM/General/OrcJIT.hs
@@ -8,6 +8,7 @@ module LLVM.General.OrcJIT (
     SymbolResolver(..),
     SymbolResolverFn,
     findSymbol,
+    findSymbolIn,
     mangleSymbol,
     withIRCompileLayer,
     withModuleSet,

--- a/llvm-general/src/LLVM/General/OrcJIT.hs
+++ b/llvm-general/src/LLVM/General/OrcJIT.hs
@@ -12,7 +12,12 @@ module LLVM.General.OrcJIT (
     mangleSymbol,
     withIRCompileLayer,
     withModuleSet,
-    withObjectLinkingLayer
+    withObjectLinkingLayer,
+    addModuleSet,
+    createObjectLinkingLayer,
+    createIRCompileLayer,
+    disposeObjectLinkingLayer,
+    disposeIRCompileLayer
   ) where
 
 import           LLVM.General.Internal.OrcJIT

--- a/llvm-general/test/LLVM/General/Test/Instrumentation.hs
+++ b/llvm-general/test/LLVM/General/Test/Instrumentation.hs
@@ -6,13 +6,14 @@ import Test.HUnit
 
 import LLVM.General.Test.Support
 
-import Control.Monad.Trans.Except 
+import Control.Monad.Trans.Except
 import Control.Monad.IO.Class
 
 import Data.Functor
 import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Data.Map as Map
+import qualified System.Info as Info
 
 import LLVM.General.Module
 import LLVM.General.Context
@@ -135,7 +136,7 @@ ast = do
 tests = testGroup "Instrumentation" [
   testGroup "basic" [
     testCase n $ do
-      triple <- getProcessTargetTriple 
+      triple <- getProcessTargetTriple
       withTargetLibraryInfo triple $ \tli -> do
         Right dl <- runExceptT $ withHostTargetMachine getTargetMachineDataLayout
         Right ast <- runExceptT ast
@@ -144,13 +145,13 @@ tests = testGroup "Instrumentation" [
         (names ast') `List.intersect` (names ast) @?= names ast
     | (n,p) <- [
      ("GCOVProfiler", defaultGCOVProfiler),
-{-
-     ("AddressSanitizer", defaultAddressSanitizer),
-     ("AddressSanitizerModule", defaultAddressSanitizerModule),
--}
-     ("MemorySanitizer", defaultMemorySanitizer),
+     -- ("AddressSanitizer", defaultAddressSanitizer),
+     -- ("AddressSanitizerModule", defaultAddressSanitizerModule),
      ("ThreadSanitizer", defaultThreadSanitizer),
-     ("BoundsChecking", BoundsChecking)--,
-    ]
+     ("BoundsChecking", BoundsChecking)
+    ] ++ if Info.os == "linux" -- or FreeBSD
+         then [("MemorySanitizer", defaultMemorySanitizer)]
+         else []
+
    ]
  ]

--- a/llvm-general/test/LLVM/General/Test/OrcJIT.hs
+++ b/llvm-general/test/LLVM/General/Test/OrcJIT.hs
@@ -11,25 +11,47 @@ import Data.Foldable
 import Data.IORef
 import Data.Word
 import Foreign.Ptr
+import qualified System.Info as Info
 
 import LLVM.General.Context
 import LLVM.General.Module
 import LLVM.General.OrcJIT
 import LLVM.General.Target
 
-testModule :: String
-testModule =
+-- | A main-style function that calls back into Haskell
+testModule1 :: String
+testModule1 =
   "; ModuleID = '<string>'\n\
   \source_filename = \"<string>\"\n\
   \\n\
   \declare i32 @testFunc()\n\
-  \define i32 @main(i32, i8**) {\n\
+  \define i32 @main(i32, i8*) {\n\
   \  %3 = call i32 @testFunc()\n\
   \  ret i32 %3\n\
   \}\n"
 
-withTestModule :: (Module -> IO a) -> IO a
-withTestModule f = withContext $ \context -> withModuleFromLLVMAssembly' context testModule f
+-- | A trivial main-style function.
+testModule3 :: String
+testModule3 =
+  unlines [ "; ModuleID = '<string>'"
+          , "source_filename = \"<string>\""
+          , ""
+          , "define i32 @main(i32, i8*) {"
+          , "ret i32 42"
+          , "}"]
+
+-- | Function that takes and uses numeric arguments
+testModule2 :: String
+testModule2 =
+  unlines [ "; ModuleID = 'test.c'"
+          , "define double @foo(double %x, double %y) #0 {"
+          , "  %1 = fadd double %x, %y"
+          , "  ret double %1"
+          , "}" ]
+
+withAssembly :: String -> (Module -> IO a) -> IO a
+withAssembly src f = withContext $ \context ->
+                       withModuleFromLLVMAssembly' context src f
 
 myTestFuncImpl :: IO Word32
 myTestFuncImpl = return 42
@@ -39,6 +61,10 @@ foreign import ccall "wrapper"
 
 foreign import ccall "dynamic"
   mkMain :: FunPtr (IO Word32) -> IO Word32
+
+foreign import ccall "dynamic"
+  mkFoo :: FunPtr (Double -> Double -> IO Double)
+        -> Double -> Double -> IO Double
 
 nullResolver :: MangledSymbol -> IO JITSymbol
 nullResolver s = putStrLn "nullresolver" >> return (JITSymbol 0 (JITSymbolFlags False False))
@@ -53,20 +79,52 @@ resolver testFunc compileLayer symbol
 
 tests :: Test
 tests =
-  testGroup "OrcJit" [
-    testCase "eager compilation" $ do
-      withTestModule $ \mod ->
-        failInIO $ withHostTargetMachine $ \tm ->
-          withObjectLinkingLayer $ \objectLayer ->
-            withIRCompileLayer objectLayer tm $ \compileLayer -> do
-              testFunc <- mangleSymbol compileLayer "testFunc"
-              withModuleSet
-                compileLayer
-                [mod]
-                (SymbolResolver (resolver testFunc compileLayer) nullResolver) $
-                \moduleSet -> do
-                  mainSymbol <- mangleSymbol compileLayer "main"
-                  JITSymbol mainFn _ <- findSymbol compileLayer mainSymbol True
-                  result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
-                  result @?= 42
-  ]
+  testGroup "OrcJit" $ [
+      testCase "trivial main" $ do
+        withAssembly testModule3 $ \mod -> do
+          failInIO $ withHostTargetMachine $ \tm ->
+            withObjectLinkingLayer $ \objectLayer ->
+              withIRCompileLayer objectLayer tm $ \compileLayer -> do
+                withModuleSet
+                  compileLayer
+                  [mod]
+                  (SymbolResolver (flip (findSymbol compileLayer) True) nullResolver) $
+                  \moduleSet -> do
+                    mainSymbol <- mangleSymbol compileLayer "main"
+                    JITSymbol mainFn _ <-
+                      findSymbolIn compileLayer moduleSet mainSymbol True
+                    result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
+                    result @?= 42
+    , testCase "argument passing" $ do
+        withAssembly testModule2 $ \mod -> do
+          failInIO $ withHostTargetMachine $ \tm ->
+            withObjectLinkingLayer $ \objectLayer ->
+              withIRCompileLayer objectLayer tm $ \compileLayer -> do
+                withModuleSet
+                  compileLayer
+                  [mod]
+                  (SymbolResolver (flip (findSymbol compileLayer) True) nullResolver) $
+                  \moduleSet -> do
+                    fooSymbol <- mangleSymbol compileLayer "foo"
+                    JITSymbol fooFn _ <- findSymbol compileLayer fooSymbol True
+                    result <- mkFoo (castPtrToFunPtr (wordPtrToPtr fooFn)) 2 40
+                    result @?= 42
+    ] ++ if Info.os == "linux"
+         then
+           [ testCase "main with callback" $ do
+               withAssembly testModule1 $ \mod -> do
+                 failInIO $ withHostTargetMachine $ \tm ->
+                   withObjectLinkingLayer $ \objectLayer ->
+                     withIRCompileLayer objectLayer tm $ \compileLayer -> do
+                       testFunc <- mangleSymbol compileLayer "testFunc"
+                       withModuleSet
+                         compileLayer
+                         [mod]
+                         (SymbolResolver (resolver testFunc compileLayer) nullResolver) $
+                         \moduleSet -> do
+                           mainSymbol <- mangleSymbol compileLayer "main"
+                           JITSymbol mainFn _ <- findSymbol compileLayer mainSymbol True
+                           result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
+                           result @?= 42
+           ]
+         else []


### PR DESCRIPTION
I have a few commits here, and I can break this into multiple PRs if that would be preferred. Each is pretty distinct and comes with a log message describing the change.

The last two commits involve changes to tests to account for varying OS support within LLVM itself, and a Haskell re-entrancy issue with GHC-8.0.1 on OS X that doesn't seem to impact @cocreature, so I have noted a guess that maybe this is another platform-dependent issue. I haven't been able to resolve that, but segfaulting as it does prevents the test suite from completing, so I am selectively disabling that test for the time being.
