### PR TITLE
Don't pass nullptr to LLVMSetPersonalityFn

### DIFF
--- a/llvm-general/src/LLVM/General/Internal/FFI/Function.hs
+++ b/llvm-general/src/LLVM/General/Internal/FFI/Function.hs
@@ -65,7 +65,7 @@ foreign import ccall unsafe "LLVM_General_SetFunctionPrefixData" setPrefixData :
 foreign import ccall unsafe "LLVM_General_HasPersonalityFn" hasPersonalityFn ::
   Ptr Function -> IO LLVMBool
 
-foreign import ccall unsafe "LLVMSetPersonalityFn" setPersonalityFn ::
+foreign import ccall unsafe "LLVM_General_SetPersonalityFn" setPersonalityFn ::
   Ptr Function -> Ptr Constant -> IO ()
 
 foreign import ccall unsafe "LLVMGetPersonalityFn" getPersonalityFn ::

--- a/llvm-general/src/LLVM/General/Internal/FFI/FunctionC.cpp
+++ b/llvm-general/src/LLVM/General/Internal/FFI/FunctionC.cpp
@@ -59,4 +59,15 @@ LLVMBool LLVM_General_HasPersonalityFn(LLVMValueRef Fn) {
   return unwrap<Function>(Fn)->hasPersonalityFn();
 }
 
+// This wrapper is necessary because LLVMSetPersonalityFn fails if
+// personalityFn is a nullptr even though the C++ API allows that.
+void LLVM_General_SetPersonalityFn(LLVMValueRef fn, LLVMValueRef personalityFn) {
+    llvm::Function* f = unwrap<Function>(fn);
+    if (personalityFn == nullptr) {
+        f->setPersonalityFn(nullptr);
+    } else {
+        f->setPersonalityFn(unwrap<Constant>(personalityFn));
+    }
+}
+
 }


### PR DESCRIPTION
Backported from cf5e9754e4b780728aeec033e58200f01e7bfbb6.
