### PR TITLE
[llvm-3.5] Support GHCi and TH

### DIFF
--- a/llvm-general/Setup.hs
+++ b/llvm-general/Setup.hs
@@ -130,10 +130,16 @@ main = do
                 condTreeComponents = condTreeComponents libraryCondTree ++ [
                   (
                     Var (Flag (FlagName "shared-llvm")),
+                    -- With flag '-fshared-llvm':
+                    --   * always link against shared library
                     CondNode (mempty { libBuildInfo = mempty { extraLibs = [sharedLib] ++ systemLibs } }) [] [],
-                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs = staticLibs ++ systemLibs } }) [] [])
+                    -- Without '-fshared-llvm':
+                    --   * executables are statically linked
+                    --   * GHCi and TH use the shared library
+                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs     = staticLibs  ++ systemLibs
+                                                                   , extraGHCiLibs = [sharedLib] ++ systemLibs } }) [] [])
                   )
-                ] 
+                ]
               }
            }
           configFlags' = configFlags {

--- a/llvm-general/Setup.hs
+++ b/llvm-general/Setup.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
 import Control.Exception (SomeException, try)
 import Control.Monad
 import Data.Maybe
@@ -8,15 +10,17 @@ import qualified Data.Map as Map
 import Data.Monoid
 import Data.Char
 import Distribution.Simple
+import Distribution.Simple.Utils (cabalVersion)
 import Distribution.Simple.PreProcess
 import Distribution.Simple.Program
 import Distribution.Simple.Setup hiding (Flag)
 import Distribution.Simple.LocalBuildInfo
+import Distribution.System
 import Distribution.PackageDescription
 import Distribution.Version
 import System.Environment
 import System.SetEnv
-import Distribution.System
+import Language.Haskell.TH
 
 -- define these selectively in C files (where _not_ using HsFFI.h),
 -- rather than universally in the ccOptions, because HsFFI.h currently defines them
@@ -93,6 +97,22 @@ addToLdLibraryPath path = do
   v <- try $ getEnv ldLibraryPathVar :: IO (Either SomeException String)
   setEnv ldLibraryPathVar (path ++ either (const "") (ldLibraryPathSep ++) v)
 
+
+addLibs :: [String] -> BuildInfo -> BuildInfo
+addLibs libs bi = bi { extraLibs = libs }
+
+-- 'extraGHCiLibs' is only available in Cabal-1.22 and later. Since GHC<8.0
+-- provides no mechanism to test which version of the Cabal library we are
+-- compiling against, use TH tricky instead.
+addGHCiLibs :: [String] -> BuildInfo -> BuildInfo
+addGHCiLibs libs bi =
+  $( case withinRange cabalVersion (orLaterVersion (Version [1,22] [])) of
+       -- Not supported with old versions of Cabal; return BuildInfo unmodified
+       False -> return $ VarE (mkName "bi")
+       -- 'bi { extraGHCiLibs = libs }'
+       True  -> return $ RecUpdE (VarE (mkName "bi")) [(mkName "extraGHCiLibs", VarE (mkName "libs"))]
+   )
+
 addLLVMToLdLibraryPath :: ConfigFlags -> IO ()
 addLLVMToLdLibraryPath configFlags = do
   llvmConfig <- getLLVMConfig configFlags
@@ -120,7 +140,10 @@ main = do
       staticLibs <- liftM (map (fromJust . stripPrefix "-l") . words) $ llvmConfig "--libs"
       systemLibs <- liftM (map (fromJust . stripPrefix "-l") . words) $ llvmConfig "--system-libs"
 
-      let genericPackageDescription' = genericPackageDescription {
+      let staticLibs' = staticLibs ++ systemLibs
+          sharedLibs' = sharedLib   : systemLibs
+
+          genericPackageDescription' = genericPackageDescription {
             condLibrary = do
               libraryCondTree <- condLibrary genericPackageDescription
               return libraryCondTree {
@@ -132,12 +155,12 @@ main = do
                     Var (Flag (FlagName "shared-llvm")),
                     -- With flag '-fshared-llvm':
                     --   * always link against shared library
-                    CondNode (mempty { libBuildInfo = mempty { extraLibs = [sharedLib] ++ systemLibs } }) [] [],
+                    CondNode (mempty { libBuildInfo = addLibs sharedLibs' mempty }) [] [],
                     -- Without '-fshared-llvm':
                     --   * executables are statically linked
                     --   * GHCi and TH use the shared library
-                    Just (CondNode (mempty { libBuildInfo = mempty { extraLibs     = staticLibs  ++ systemLibs
-                                                                   , extraGHCiLibs = [sharedLib] ++ systemLibs } }) [] [])
+                    Just (CondNode (mempty { libBuildInfo = addLibs     staticLibs'
+                                                          $ addGHCiLibs sharedLibs' mempty }) [] [])
                   )
                 ]
               }


### PR DESCRIPTION
Enables llvm-general to be used out-of-the-box with GHCi and TemplateHaskell whenever possible. This requires the LLVM shared library to be available, but _only_ if you use GHCi/TH; regular compiles work as usual. Since cabal dependencies can not specify flags, this also makes llvm-general easier to work with as a dependency.

Requires Cabal-1.22 or newer, otherwise keeps the old behaviour.

Fixes #84, #85.
Ping #197.

## Current behaviour

* `-fshared-llvm=True`
  - executables are linked against the shared library, and required to compile llvm-general
  - GHCi and TH work

* `-fshared-llvm=False` (default)
  - executables are statically linked
  - GHCi and TH fail in strange and mysterious ways, e.g.:
```
ghc: libLLVMSupport.a: unhandled ELF relocation(RelA) type 42
```
or
```
    ghc:
    lookupSymbol failed in relocateSection (RELOC_GOT)
    /usr/local/homebrew/Cellar/llvm35/3.5.1/lib/llvm-3.5/lib/libLLVMSupport.a: unknown symbol `___dso_handle'
```
or maybe
```
    <no location info>:
        ghc: panic! (the 'impossible' happened)
      (GHC version 7.10.3 for x86_64-apple-darwin):
    	Dynamic linker not initialised

    Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug
```

## New behaviour

* `-fshared-llvm=True`
  - same as above

* `-fshared-llvm=False` (default)
  - executables are statically linked
  - GHCi and TH work, _if_ the shared library is available. If not, it still fails, but you get the more reasonable error message:
```
can't load .so/.DLL for: libLLVM-3.5.1.dylib (dlopen(libLLVM-3.5.1.dylib, 5): image not found)
```
