### PR TITLE
Detect shared library name with llvm-config

### DIFF
--- a/llvm-general/Setup.hs
+++ b/llvm-general/Setup.hs
@@ -67,7 +67,7 @@ instance OldHookable (Args -> PackageDescription -> LocalBuildInfo -> UserHooks 
 llvmProgram :: Program
 llvmProgram = (simpleProgram "llvm-config") {
   programFindLocation = programSearch (programFindLocation . simpleProgram),
-  programFindVersion = 
+  programFindVersion =
     let
       stripSuffix suf str = let r = reverse in liftM r (stripPrefix (r suf) (r str))
       svnToTag v = maybe v (++"-svn") (stripSuffix "svn" v)
@@ -76,13 +76,13 @@ llvmProgram = (simpleProgram "llvm-config") {
       \v p -> findProgramVersion "--version" (svnToTag . trim) v p
  }
 
-getLLVMConfig :: ConfigFlags -> IO (String -> IO String)
+getLLVMConfig :: ConfigFlags -> IO ([String] -> IO String)
 getLLVMConfig configFlags = do
   let verbosity = fromFlag $ configVerbosity configFlags
   (program, _, _) <- requireProgramVersion verbosity llvmProgram
                      (withinVersion llvmVersion)
                      (configPrograms configFlags)
-  return $ getProgramOutput verbosity program . return
+  return $ getProgramOutput verbosity program
 
 addToLdLibraryPath :: String -> IO ()
 addToLdLibraryPath path = do
@@ -96,7 +96,7 @@ addToLdLibraryPath path = do
 addLLVMToLdLibraryPath :: ConfigFlags -> IO ()
 addLLVMToLdLibraryPath configFlags = do
   llvmConfig <- getLLVMConfig configFlags
-  [libDir] <- liftM lines $ llvmConfig "--libdir"
+  [libDir] <- liftM lines $ llvmConfig ["--libdir"]
   addToLdLibraryPath libDir
 
 -- | These flags are not relevant for us and dropping them allows
@@ -110,27 +110,26 @@ ignoredCFlags = ["-Wcovered-switch-default", "-Wdelete-non-virtual-dtor", "-fcol
 
 main = do
   let origUserHooks = simpleUserHooks
-                  
+
   defaultMainWithHooks origUserHooks {
     hookedPrograms = [ llvmProgram ],
 
     confHook = \(genericPackageDescription, hookedBuildInfo) configFlags -> do
       llvmConfig <- getLLVMConfig configFlags
       llvmCxxFlags <- do
-        rawLlvmCxxFlags <- llvmConfig "--cxxflags"
+        rawLlvmCxxFlags <- llvmConfig ["--cxxflags"]
         return (words rawLlvmCxxFlags \\ ignoredCxxFlags)
       let stdLib = maybe "stdc++"
                          (drop (length stdlibPrefix))
                          (find (isPrefixOf stdlibPrefix) llvmCxxFlags)
             where stdlibPrefix = "-stdlib=lib"
-      includeDirs <- liftM lines $ llvmConfig "--includedir"
-      libDirs@[libDir] <- liftM lines $ llvmConfig "--libdir"
-      [llvmVersion] <- liftM lines $ llvmConfig "--version"
-      let sharedLib = case llvmVersion of
-                        "3.2" -> "LLVM-3.2svn"
-                        x -> "LLVM-" ++ x
-      staticLibs <- liftM (map (fromJust . stripPrefix "-l") . words) $ llvmConfig "--libs"
-      systemLibs <- liftM (map (fromJust . stripPrefix "-l") . words) $ llvmConfig "--system-libs"
+      includeDirs <- liftM lines $ llvmConfig ["--includedir"]
+      libDirs@[libDir] <- liftM lines $ llvmConfig ["--libdir"]
+      [llvmVersion] <- liftM lines $ llvmConfig ["--version"]
+      let getLibs = liftM (map (fromJust . stripPrefix "-l") . words) . llvmConfig
+      sharedLibs <- getLibs ["--libs", "--link-shared"]
+      staticLibs <- getLibs ["--libs", "--link-static"]
+      systemLibs <- getLibs ["--system-libs"]
 
       let genericPackageDescription' = genericPackageDescription {
             condLibrary = do
@@ -146,10 +145,10 @@ main = do
                 condTreeComponents = condTreeComponents libraryCondTree ++ [
                   (
                     Var (Flag (FlagName "shared-llvm")),
-                    CondNode (mempty { libBuildInfo = mempty { extraLibs = [sharedLib] ++ systemLibs } }) [] [],
+                    CondNode (mempty { libBuildInfo = mempty { extraLibs = sharedLibs ++ systemLibs } }) [] [],
                     Just (CondNode (mempty { libBuildInfo = mempty { extraLibs = staticLibs ++ systemLibs } }) [] [])
                   )
-                ] 
+                ]
               }
            }
           configFlags' = configFlags {
@@ -167,7 +166,7 @@ main = do
                   runPreProcessor = \inFiles outFiles verbosity -> do
                       llvmConfig <- getLLVMConfig (configFlags localBuildInfo)
                       llvmCFlags <- do
-                          rawLlvmCFlags <- llvmConfig "--cflags"
+                          rawLlvmCFlags <- llvmConfig ["--cflags"]
                           return (words rawLlvmCFlags \\ ignoredCFlags)
                       let buildInfo' = buildInfo { ccOptions = llvmCFlags }
                       runPreProcessor (origHsc buildInfo' localBuildInfo) inFiles outFiles verbosity


### PR DESCRIPTION
Currently, `llvm-general`'s `Setup.hs` script hardcodes the name of of the shared LLVM library based on its version number (e.g., with `llvm-3.9`, it hardcodes `LLVM-3.9`). The problem is that the MinGW-w64 (Windows) version of LLVM doesn't put version numbers at the end of its library files - that is, it names it `libLLVM.dll.a` instead of `libLLVM-3.9.dll.a`. As a result, `llvm-general` fails to configure on Windows because it can't find the right shared library name:

```
$ cabal configure -fshared-llvm
Resolving dependencies...
Configuring llvm-general-3.9.0.0...
Warning: Instead of 'cc-options: -IC:\msys64\mingw64/include' use
'include-dirs: C:\msys64\mingw64/include'
setup.exe: Missing dependency on a foreign library:
* Missing C library: LLVM-3.9.1
This problem can usually be solved by installing the system package that
provides this library (you may need the "-dev" version). If the library is
already installed but in a non-standard location then you can use the flags
--extra-include-dirs= and --extra-lib-dirs= to specify where it is.
```

See https://github.com/AccelerateHS/accelerate/pull/342#issuecomment-274116175 for an example of where this problem arose.

What seems like the obvious solution here is to instead just determine what the shared library name is from `llvm-config`, like `Setup.hs` currently does for the static library names. This PR does just that.

Note: I'm unfamiliar with how PRs for this library are supposed to work, since there's one branch for every LLVM version. Since I happen to have `llvm-3.9` installed, I opened this PR on the `llvm-3.9` branch. If you'd prefer that it be done differently, please let me know.